### PR TITLE
Update certificates earlier

### DIFF
--- a/src/redfish_certrobot/__main__.py
+++ b/src/redfish_certrobot/__main__.py
@@ -104,7 +104,7 @@ def main():
     _setup_logging()
 
     now = datetime.now(timezone.utc)
-    max_delta = timedelta(days=7)
+    max_delta = timedelta(days=14)
     best_before = now + max_delta
 
     conn = openstack.connect()


### PR DESCRIPTION
We send some notification 10 days advance,
the updater is run every two days, so run things
14 days before to be sure it will done before.