### PR TITLE
Fix nodes() call

### DIFF
--- a/src/redfish_certrobot/__main__.py
+++ b/src/redfish_certrobot/__main__.py
@@ -175,7 +175,7 @@ def main():
             return address, type(e).__name__
 
     with ThreadPoolExecutor(max_workers=16) as executor:
-        results = executor.map(_dispatch_logged, nodes.nodes(conn))
+        results = executor.map(_dispatch_logged, nodes.nodes())
 
     return _summary(results)
 


### PR DESCRIPTION
The nodes() function no longer accepts a conn argument. Update __main__.py to call nodes() without conn.