### PR TITLE
Handle None returns in _dispatch_logged

### DIFF
--- a/src/redfish_certrobot/__main__.py
+++ b/src/redfish_certrobot/__main__.py
@@ -158,9 +158,13 @@ def main():
             return address, now_utc  # Not 100% correct, but sufficient
 
     def _dispatch_logged(item):
-        address, *_ = item
+        address = item[0] if item else "<unknown>"
         try:
-            return _dispatch(item)
+            result = _dispatch(item)
+            if result is None:  # guard against bad returns
+                LOG.error("Dispatch returned None for %s", address)
+                return address, "Dispatch returned None"
+            return result
         except (
             sushy.exceptions.ConnectionError,
             sushy.exceptions.HTTPError,


### PR DESCRIPTION
Previously, _dispatch could return None, causing _summary() to fail with TypeError: cannot unpack non-iterable NoneType. Now _dispatch_logged logs an error and returns (address, 'Dispatch returned None') to prevent this.