### PR TITLE
Include nodes in maintenance

### DIFF
--- a/src/redfish_certrobot/nodes.py
+++ b/src/redfish_certrobot/nodes.py
@@ -30,7 +30,7 @@ GRAPHQL_QUERY = """
 query {
   device_list(filters: {
     status: "active"
-    OR: { status: "staged" },
+    OR: { status: "staged" OR: { status: "maintenance"}},
     tag: "server",
     tenant_group_id: "3",
     tenant_id: "1",


### PR DESCRIPTION
Also include nodes in maintenance in netbox. These need valid certificates and otherwise it can happen that the cert expires while they get fixed. This will probably result in more connection issues as some of the nodes in maintenance might not be reachable.