### PR TITLE
issues: fix hpe data

### DIFF
--- a/src/redfish_certrobot/issue.py
+++ b/src/redfish_certrobot/issue.py
@@ -252,10 +252,10 @@ def _generate_csr_hpe(manager, address):
             "City": "Walldorf",
             "CommonName": address,
             "Country": "DE",
-            "IncludeIP": False,
+            "IncludeIP": false,
             "OrgName": "SAP",
             "OrgUnit": "CC",
-            "State": "BW",
+            "State": "BW"
         }
         with csr_path.open(mode="w", encoding="utf-8") as csr_file:
             result = client.post(target_uri, data=data)


### PR DESCRIPTION
The json for HPE can't end with a comma and the proper value for IncludeIP is a a boolean but apparently only in lowercase. I tried it with "False" as here and it fails for a ProLiant DL560 Gen11 with iLO 1.66. With the changes it works.