### PR TITLE
issue: fix for hpe fix

### DIFF
--- a/src/redfish_certrobot/issue.py
+++ b/src/redfish_certrobot/issue.py
@@ -247,15 +247,15 @@ def _generate_csr_hpe(manager, address):
     target_uri = f"{manager.path}/SecurityService/HttpsCert/Actions/HpeHttpsCert.GenerateCSR/"
 
     if invalid_file(csr_path):
-        LOG.debug("Generating new CSR")
+        LOG.info("Generating new CSR")
         data = {
-            "City": "Walldorf",
-            "CommonName": address,
-            "Country": "DE",
-            "IncludeIP": false,
             "OrgName": "SAP",
             "OrgUnit": "CC",
-            "State": "BW"
+            "CommonName": address,
+            "Country": "DE",
+            "State": "BW",
+            "City": "Walldorf",
+            "IncludeIP": False
         }
         with csr_path.open(mode="w", encoding="utf-8") as csr_file:
             result = client.post(target_uri, data=data)


### PR DESCRIPTION
This is a python dict so "False" is correcti. Using a "false" will
generate a python error as that is not valid python.
The data musst still be converted to json but sushy calls requests
not with data= but with json= meaning this will automatically get put
into a json.dumps and Python ¨False" will become JSON "false" however
it seems the iLO expects the data in excactly this order. Different
orders lead to invalidjson issue. This was tested to work in QA.

The HPE docs mention the order should only matter for iLOrest but it
seems it matters for json as well.
<https://servermanagementportal.ext.hpe.com/docs/redfishservices/ilos/supplementdocuments/securityservice>
