### PR TITLE
Add Fujitsu certificate support

### DIFF
--- a/src/redfish_certrobot/__main__.py
+++ b/src/redfish_certrobot/__main__.py
@@ -151,6 +151,10 @@ def main():
                 if manager_name != "RMC Manager":
                     return issue.install_cert_hpe(address, root, best_before_utc)
 
+            # Fujitsu iRMC reports manufacturer as FSAS
+            if manufacturer == "fsas":
+                return issue.install_cert_fujitsu(address, root, best_before_utc, force_renewal=force_renewal)
+
             version = _version_check(manufacturer, root)
             if not version:
                 return address, "Invalid version"

--- a/src/redfish_certrobot/issue.py
+++ b/src/redfish_certrobot/issue.py
@@ -24,7 +24,9 @@ import threading
 import typing
 from dataclasses import dataclass
 from datetime import datetime, UTC
-
+import tempfile
+import shutil
+from cryptography.hazmat.primitives import serialization
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 
@@ -87,9 +89,10 @@ _LEGO_LOCK = threading.BoundedSemaphore(8)  # Just a guess, higher values might 
 
 
 @contextmanager
-def _request_cert(csr_path):
-    crt_path = pathlib.Path(f".lego/certificates/{csr_path.with_suffix('.crt')}")
-    if invalid_file(crt_path):
+def _request_cert(csr_path, force=False):
+    crt_path = pathlib.Path(".lego/certificates") / f"{csr_path.stem}.crt"
+
+    if force or invalid_file(crt_path):
         LOG.debug("Requesting certificate")
         with _LEGO_LOCK:
             subprocess.run(
@@ -269,13 +272,32 @@ def _generate_csr_hpe(manager, address):
     yield csr_path
     csr_path.unlink(missing_ok=True)
 
+def verify_cert_key_match(cert_path, key_path):
+    with cert_path.open("rb") as f:
+        cert = x509.load_pem_x509_certificate(f.read())
+
+    with key_path.open("rb") as f:
+        key = serialization.load_pem_private_key(
+            f.read(),
+            password=None,
+        )
+
+    cert_public_numbers = cert.public_key().public_numbers()
+    key_public_numbers = key.public_key().public_numbers()
+
+    if cert_public_numbers != key_public_numbers:
+        raise RuntimeError("Certificate and private key do NOT match")
+
+    LOG.info("Certificate and private key MATCH")
+
 
 @contextmanager
 def _generate_csr_fujitsu(address):
-    csr_path = pathlib.Path(f"{address}.csr")
-    key_path = pathlib.Path(f"{address}.key")
+    temp_dir = pathlib.Path(tempfile.mkdtemp(prefix="redfish-certrobot-"))
+    csr_path = temp_dir / f"{address}.csr"
+    key_path = temp_dir / f"{address}.key"
 
-    if invalid_file(csr_path) or invalid_file(key_path):
+    try:
         LOG.info("Generating Fujitsu CSR")
 
         subprocess.run(
@@ -314,11 +336,9 @@ def _generate_csr_fujitsu(address):
             check=True,
         )
 
-    try:
         yield csr_path, key_path
     finally:
-        csr_path.unlink(missing_ok=True)
-        key_path.unlink(missing_ok=True)
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 def _convert_private_key_to_pkcs1(key_path):
@@ -449,8 +469,11 @@ def install_cert_fujitsu(address, root, best_before, force_renewal=False):
 
     LOG.info("Installing new Fujitsu certificate for %s", address)
 
+    replace_result = False
+
     with _generate_csr_fujitsu(address) as (csr_path, key_path):
-        with _request_cert(csr_path) as cert_path:
+        with _request_cert(csr_path, force=True) as cert_path:
+            verify_cert_key_match(cert_path, key_path)
             cert_content = _get_certificate_content(cert_path)
             replace_result = replace_certificate_fujitsu(manager, cert_content, key_path)
 
@@ -524,7 +547,7 @@ def replace_certificate_fujitsu(manager, cert_content, key_path):
             key_content = key_file.read()
 
         url = (
-            "Managers/iRMC/NetworkProtocol/HTTPS/Certificates/Certificate0/"
+            f"{manager.path}/NetworkProtocol/HTTPS/Certificates/Certificate0/"
             "Actions/Oem/FsasCertificates.ReplaceCertificate"
         )
         files = {

--- a/src/redfish_certrobot/issue.py
+++ b/src/redfish_certrobot/issue.py
@@ -270,6 +270,76 @@ def _generate_csr_hpe(manager, address):
     csr_path.unlink(missing_ok=True)
 
 
+@contextmanager
+def _generate_csr_fujitsu(address):
+    csr_path = pathlib.Path(f"{address}.csr")
+    key_path = pathlib.Path(f"{address}.key")
+
+    if invalid_file(csr_path) or invalid_file(key_path):
+        LOG.info("Generating Fujitsu CSR")
+
+        subprocess.run(
+            [
+                "openssl",
+                "genrsa",
+                "-out",
+                str(key_path),
+                "4096",
+            ],
+            check=True,
+        )
+
+        subprocess.run(
+            [
+                "openssl",
+                "req",
+                "-new",
+                "-utf8",
+                "-key",
+                str(key_path),
+                "-out",
+                str(csr_path),
+                "-batch",
+                "-subj",
+                (
+                    f"/C={CSR_COUNTRY}"
+                    f"/ST={CSR_STATE}"
+                    f"/L={CSR_CITY}"
+                    f"/O={CSR_ORGANIZATION}"
+                    f"/CN={address}"
+                ),
+                "-addext",
+                f"subjectAltName=DNS:{address}",
+            ],
+            check=True,
+        )
+
+    try:
+        yield csr_path, key_path
+    finally:
+        csr_path.unlink(missing_ok=True)
+        key_path.unlink(missing_ok=True)
+
+
+def _convert_private_key_to_pkcs1(key_path):
+    pkcs1_path = pathlib.Path(str(key_path).replace(".key", "_pkcs1.pem"))
+
+    subprocess.run(
+        [
+            "openssl",
+            "rsa",
+            "-traditional",
+            "-in",
+            str(key_path),
+            "-out",
+            str(pkcs1_path),
+        ],
+        check=True,
+    )
+
+    return pkcs1_path
+
+
 def import_ssl_certificate_hpe(manager, cert_content):
     client = manager._conn
     target_uri = f"{manager.path}/SecurityService/HttpsCert/Actions/HpeHttpsCert.ImportCertificate/"
@@ -357,6 +427,40 @@ def install_cert_hpe(address, root, best_before):
         manager.reset_manager(ResetType.GRACEFUL_RESTART)
 
 
+def get_current_cert_fujitsu(manager):
+    target_uri = f"{manager.path}/NetworkProtocol/HTTPS/Certificates/Certificate0"
+    response = manager._conn.get(target_uri)
+    return response.json()
+
+
+def install_cert_fujitsu(address, root, best_before, force_renewal=False):
+    manager = root.get_manager()
+    # Check existing certificate first
+    try:
+        cert = get_current_cert_fujitsu(manager)
+        valid_until = parser.parse(cert["HttpsCertificate"]["ValidNotAfter"])
+
+        if not force_renewal and valid_until > best_before:
+            LOG.info("Fujitsu certificate valid until %s", valid_until)
+            return address, valid_until
+
+    except Exception as error:
+        LOG.warning("Could not read Fujitsu current certificate: %s", error)
+
+    LOG.info("Installing new Fujitsu certificate for %s", address)
+
+    with _generate_csr_fujitsu(address) as (csr_path, key_path):
+        with _request_cert(csr_path) as cert_path:
+            cert_content = _get_certificate_content(cert_path)
+            replace_result = replace_certificate_fujitsu(manager, cert_content, key_path)
+
+    if replace_result:
+        manager.reset_manager(ResetType.GRACEFUL_RESTART)
+        return address, datetime.now(UTC)
+
+    return address, "Failed to replace Fujitsu certificate"
+
+
 def _find_manager_cert(root, manufacturer):
     try:
         manager = root.get_manager()
@@ -412,9 +516,49 @@ def replace_certificate_dell(major_version, root, cert_content):
     return False
 
 
+def replace_certificate_fujitsu(manager, cert_content, key_path):
+    pkcs1_key_path = _convert_private_key_to_pkcs1(key_path)
+
+    try:
+        with pkcs1_key_path.open(encoding="utf-8") as key_file:
+            key_content = key_file.read()
+
+        url = (
+            "Managers/iRMC/NetworkProtocol/HTTPS/Certificates/Certificate0/"
+            "Actions/Oem/FsasCertificates.ReplaceCertificate"
+        )
+        files = {
+            "certificate": (
+                "certificate.pem", cert_content, "application/x-pem-file"
+            ),
+            "private_key": (
+                "private.pem", key_content, "application/x-pem-file"
+            ),
+        }
+
+        response = manager._conn.post(url, files=files, timeout=30.0)
+
+        if response.status_code == 204:
+            LOG.info("Fujitsu iRMC certificate replaced successfully")
+            return True
+
+        LOG.error(
+            "Fujitsu certificate replacement failed: %s %s",
+            response.status_code,
+            response.text,
+        )
+        return False
+
+    finally:
+        pkcs1_key_path.unlink(missing_ok=True)
+
+
 def replace_certificate(manufacturer, version, root, cert, cert_content):
     if manufacturer == "dell":
         return replace_certificate_dell(version, root, cert_content)
+
+    if manufacturer == "fsas":
+        raise RuntimeError("Fujitsu certificate replacement requires a private key; use install_cert_fujitsu instead")
 
     certificate_service = root.get_certificate_service()
 

--- a/src/redfish_certrobot/nodes.py
+++ b/src/redfish_certrobot/nodes.py
@@ -34,7 +34,7 @@ query {
     tag: "server",
     tenant_group_id: "3",
     tenant_id: "1",
-    manufacturer_id: ["16", "4", "9"], # this is Dell, HPE and Lenovo
+    manufacturer_id: ["16", "4", "9", "24"], # this is Dell, HPE, Lenovo and Fujitsu
     region: "%s"
   }) {
     name


### PR DESCRIPTION
Adds Fujitsu iRMC certificate support to redfish-certrobot.

1. Detect Fujitsu/FSAS nodes.
2. Generate the CSR and private key using OpenSSL.
3. Obtain the certificate via the ACME API.
4. Upload the certificate and private key using the Fujitsu FsasCertificates.ReplaceCertificate Redfish action.
5. Reset the iRMC after successful certificate replacement.
6. Tested successfully on node008r-bb098.